### PR TITLE
docs(README): fix usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@
 3. Add the following configuration to `~/.julia/config/startup.jl`:
    
     ```julia
-    import OhMyREPL: colorscheme
+    import OhMyREPL
     include("catppuccin.jl")
-    colorscheme!("CatppuccinLatte") # or 'CatppuccinFrappe', 'CatppuccinMacchiato', 'CatppuccinMocha'
+    OhMyREPL.colorscheme!("CatppuccinLatte") # or 'CatppuccinFrappe', 'CatppuccinMacchiato', 'CatppuccinMocha'
     ```
 
 ## 💝 Thanks to


### PR DESCRIPTION
Currently, the code snippet in the usage section results in an error due to how `colorscheme` is being imported from `OhMyREPL` for some reason. This PR fixes it so it works.